### PR TITLE
Code simplification and feature additions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,41 @@
 Note: Requires Python 3.8+
 # End-to-end WSI processing pipeline
-This repository contains two main scripts for the preProcessing of the Whole Slide Images (WSIs) as an initial step for histopathological deep learning.
+This repository contains a pipeline for the pre-processing of Whole Slide Images (WSIs) as an initial step for histopathological deep learning.
+In this pipeline, we are using the Macenko normalization adapted method from https://github.com/wanghao14/Stain_Normalization.git
 
-
+F
 0. Clone and enter this repository on your device
-1. _For lab members_: download ```e2e_container.sif``` from the ZIH at ```/glw/ekfz_ai/ekfz_proj/Omar```
-2. _For externals_: Install the Singularity dependencies and container with
+1. Install the Singularity dependencies and build container, requires (fake) root access
 ```
   cd mlcontext
   sh setup.sh
   cd ..
 ```
-3. Edit [run_wsi_norm.sh](run_wsi_norm.sh) and specify your paths. Observe the following arguments:
+2. Edit [run_wsi_norm.sh](run_wsi_norm.sh) and specify your paths. Observe the following arguments:
 
 Input Variable name | Description
 --- | --- 
--o | Path to the output folder where normalised .JPGs and normalised features are saved | 
+-o | Path to the output folder where features are saved | 
 --wsi-dir | Path to the WSI folder
---cache-dir | Path to the output folder where tiles are saved
+--cache-dir | Path to the output folder where intermediate slide JPGs are saved
 -m | Path to the SSL model used for feature extraction
 -e | Feature extractor, 'retccl' or 'ctranspath'
+-c | Number of CPU cores, optional
+--del_slide | Delete original slide from your drive, optional
+--no-norm | Do not apply Macenko normalization, optional
 
-usage: 
+Example usage: 
 ```python
 python wsi-norm.py \
-    -o OUTPUTPATH \
-    --wsi-dir INPUTPATH \ 
-    --cache-dir OUTPUTPATH \
-    -m MODELPATH \
-    -e FEATUREEXTRACTOR
+    -o FEATURE_OUTPUT_PATH \
+    --wsi-dir INPUT_PATH \ 
+    --cache-dir IMAGES_OUTPUT_PATH \
+    -m MODEL_PATH \
+    -e FEATURE_EXTRACTOR \
+    -c NUM_OF_CPU_CORES \
+    --del-slide \
+    --no-norm 
 ```
-4. Run the script inside container env with [run_wsi_norm.sh](run_wsi_norm.sh):
-`singularity run --nv e2e_container.sif run_wsi_norm.sh`
+3. Run the script inside container env with [run_wsi_norm.sh](run_wsi_norm.sh):
+`singularity run --nv -B /:/ e2e_container.sif run_wsi_norm.sh`
 
-In this script, we are using the Macenko normalization adapted method from https://github.com/wanghao14/Stain_Normalization.git

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ This repository contains a pipeline for the pre-processing of Whole Slide Images
 In this pipeline, we are using the Macenko normalization adapted method from https://github.com/wanghao14/Stain_Normalization.git
 
 For usage on a local computer:
+
 0. Clone and enter this repository on your device
 1. Install the Singularity dependencies and build container, requires (fake) root access
 ```

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Input Variable name | Description
 -m | Path to the SSL model used for feature extraction
 -e | Feature extractor, 'retccl' or 'ctranspath'
 -c | Number of CPU cores, optional
---del_slide | Delete original slide from your drive, optional
+--del-slide | Delete original slide from your drive, optional
 --no-norm | Do not apply Macenko normalization, optional
 --only-fex | Read the JPGs from previous runs and go straight into feature extraction
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Note: Requires Python 3.8+
 This repository contains a pipeline for the pre-processing of Whole Slide Images (WSIs) as an initial step for histopathological deep learning.
 In this pipeline, we are using the Macenko normalization adapted method from https://github.com/wanghao14/Stain_Normalization.git
 
-F
+For usage on a local computer:
 0. Clone and enter this repository on your device
 1. Install the Singularity dependencies and build container, requires (fake) root access
 ```
@@ -23,6 +23,7 @@ Input Variable name | Description
 -c | Number of CPU cores, optional
 --del_slide | Delete original slide from your drive, optional
 --no-norm | Do not apply Macenko normalization, optional
+--only-fex | Read the JPGs from previous runs and go straight into feature extraction
 
 Example usage: 
 ```python
@@ -34,7 +35,7 @@ python wsi-norm.py \
     -e FEATURE_EXTRACTOR \
     -c NUM_OF_CPU_CORES \
     --del-slide \
-    --no-norm 
+    --no-norm \
 ```
 3. Run the script inside container env with [run_wsi_norm.sh](run_wsi_norm.sh):
 `singularity run --nv -B /:/ e2e_container.sif run_wsi_norm.sh`

--- a/concurrent_canny_rejection.py
+++ b/concurrent_canny_rejection.py
@@ -38,7 +38,7 @@ def canny_fcn(patch: np.array) -> Tuple[np.array, bool]:
         return (patch, False)
 
 
-def reject_background(img: np.array, patch_size: Tuple[int,int], step: int, save_tiles: bool = False, outdir: Path = None) -> \
+def reject_background(img: np.array, patch_size: Tuple[int,int], step: int, save_tiles: bool = False, outdir: Path = None, cores: int = 8) -> \
 Tuple[ndarray, ndarray, List[Any]]:
     img_shape = img.shape
     print(f"\nSize of WSI: {img_shape}")
@@ -49,9 +49,8 @@ Tuple[ndarray, ndarray, List[Any]]:
     print(f"Splitting WSI into {x} tiles and Canny background rejection...")
     begin = time.time()
     patches_shapes_list=[]
-    # begin_time_list = []
-    #changed maximum threads from 32 to os.cpu_count()
-    with futures.ThreadPoolExecutor(os.cpu_count()) as executor: #os.cpu_count()
+
+    with futures.ThreadPoolExecutor(cores) as executor: #os.cpu_count()
         future_coords: Dict[futures.Future, int] = {}
         i_range = range(img_shape[0]//patch_size[0])
         j_range = range(img_shape[1]//patch_size[1])

--- a/concurrent_canny_rejection.py
+++ b/concurrent_canny_rejection.py
@@ -91,13 +91,13 @@ def test_canny_fcn():
     assert patch.shape == (224, 224, 3)
     assert is_rejected == False
 
-
-# test reject_background
+# test reject_background function
 def test_reject_background():
-    img = cv2.imread('test.jpg')
-    patch_size = (224, 224)
-    step = 224
-    ordered_patch_list, rejected_tile_list, patches_shapes_list = reject_background(img, patch_size, step)
-    assert ordered_patch_list.shape == (1, 224, 224, 3)
-    assert rejected_tile_list.shape == (1,)
-    assert patches_shapes_list == [(224, 224, 3)]
+    img = np.random.randint(0, 255, size=(1000, 1000, 3), dtype=np.uint8)
+    bg_reject_array, rejected_tile_array, patch_shapes = reject_background(img = img, patch_size=(224,224), step=224, outdir='.', save_tiles=False)
+    assert bg_reject_array.shape == (1000, 1000, 3)
+    assert rejected_tile_array.shape == (1000, 1000, 3)
+    assert patch_shapes == (224,224)
+
+    # test that the rejected tiles are all black
+    assert np.all(rejected_tile_array == 0)

--- a/feature_extractors.py
+++ b/feature_extractors.py
@@ -1,0 +1,79 @@
+import hashlib
+from pathlib import Path
+from marugoto.marugoto.extract.extract import extract_features_
+from marugoto.marugoto.extract.xiyue_wang.RetCLL import ResNet
+from marugoto.marugoto.extract.ctranspath.swin_transformer import swin_tiny_patch4_window7_224, ConvStem
+import torch
+import torch.nn as nn
+import PIL
+import numpy as np
+import os
+
+class FeatureExtractor:
+    def __init__(self, model_type):
+        self.model_type = model_type
+
+    def extract_features(self, norm_wsi_img: PIL.Image, wsi_name: str, coords: list, checkpoint_path: str, outdir: Path, **kwargs):
+        """Extracts features from slide tiles.
+        Args:
+            checkpoint_path:  Path to the model checkpoint file.
+        """
+        sha256 = hashlib.sha256()
+        with open(checkpoint_path, 'rb') as f:
+            while True:
+                data = f.read(1 << 16)
+                if not data:
+                    break
+                sha256.update(data)
+
+        if self.model_type == 'retccl':
+            assert sha256.hexdigest() == '931956f31d3f1a3f6047f3172b9e59ee3460d29f7c0c2bb219cbc8e9207795ff'
+
+            model = ResNet.resnet50(num_classes=128, mlp=False, two_branch=False, normlinear=True)
+            pretext_model = torch.load(checkpoint_path, map_location=torch.device('cpu'))
+            model.fc = nn.Identity()
+            model.load_state_dict(pretext_model, strict=True)
+
+            if torch.cuda.is_available():
+                model = model.cuda()
+
+            print("RetCCL model successfully initialised...")
+
+            return extract_features_(norm_wsi_img=norm_wsi_img, wsi_name=wsi_name, coords=coords,
+                                     model=model, outdir=outdir, model_name='xiyuewang-retcll-931956f3', **kwargs)
+
+        elif self.model_type == 'ctranspath':
+            assert sha256.hexdigest() == '7c998680060c8743551a412583fac689db43cec07053b72dfec6dcd810113539'
+
+            model = swin_tiny_patch4_window7_224(embed_layer=ConvStem, pretrained=False)
+            model.head = nn.Identity()
+
+            ctranspath = torch.load(checkpoint_path, map_location=torch.device('cpu'))
+            if torch.cuda.is_available():
+                model = model.cuda()
+            # print keys and values of ctranspath
+
+            model.load_state_dict(ctranspath['model'], strict=True)
+            print("CTransPath model successfully initialised...")
+
+            return extract_features_(norm_wsi_img=norm_wsi_img, wsi_name=wsi_name, coords=coords,
+                                     model=model, outdir=outdir,model_name='xiyuewang-ctranspath-7c998680', **kwargs)
+
+        else:
+            raise ValueError('Invalid model type')
+        
+
+# test extract_xiyuewang_features_ function
+def test_extract_xiyuewang_features_():
+    img = np.random.randint(0, 255, size=(1000, 1000, 3), dtype=np.uint8)
+    feature_extractor = FeatureExtractor('retccl')
+    feature_extractor.extract_features(norm_wsi_img=img, wsi_name='test', coords=[(0,0)], checkpoint_path='.', outdir='.')
+
+    # test that the output file exists
+    assert os.path.exists('test.h5')
+
+    # test that the output file is not empty
+    assert os.path.getsize('test.h5') > 0
+
+    # remove the output file
+    os.remove('test.h5')

--- a/loading_slides.py
+++ b/loading_slides.py
@@ -19,7 +19,7 @@ def _load_tile(
     return np.array(tile)
 
 
-def load_slide(slide: openslide.OpenSlide, target_mpp: float = 256/224) -> np.ndarray:
+def load_slide(slide: openslide.OpenSlide, target_mpp: float = 256/224, cores: int = 8) -> np.ndarray:
     """Loads a slide into a numpy array."""
     # We load the slides in tiles to
     #  1. parallelize the loading process
@@ -40,7 +40,7 @@ def load_slide(slide: openslide.OpenSlide, target_mpp: float = 256/224) -> np.nd
             return None
     tile_target_size = np.round(stride*slide_mpp/target_mpp).astype(int)
     #changed max amount of threads used
-    with futures.ThreadPoolExecutor(os.cpu_count()) as executor:
+    with futures.ThreadPoolExecutor(cores) as executor:
         # map from future to its (row, col) index
         future_coords: Dict[futures.Future, Tuple[int, int]] = {}
         for i in range(steps):  # row

--- a/loading_slides.py
+++ b/loading_slides.py
@@ -1,0 +1,122 @@
+from pathlib import Path
+from typing import Dict, Tuple
+from concurrent import futures
+import logging
+import os
+from matplotlib import pyplot as plt
+import openslide
+from tqdm import tqdm
+import numpy as np
+import PIL
+
+PIL.Image.MAX_IMAGE_PIXELS = None
+
+def _load_tile(
+    slide: openslide.OpenSlide, pos: Tuple[int, int], stride: Tuple[int, int], target_size: Tuple[int, int]
+) -> np.ndarray:
+    # Loads part of a WSI. Used for parallelization with ThreadPoolExecutor
+    tile = slide.read_region(pos, 0, stride).convert('RGB').resize(target_size)
+    return np.array(tile)
+
+
+def load_slide(slide: openslide.OpenSlide, target_mpp: float = 256/224) -> np.ndarray:
+    """Loads a slide into a numpy array."""
+    # We load the slides in tiles to
+    #  1. parallelize the loading process
+    #  2. not use too much data when then scaling down the tiles from their
+    #     initial size
+    steps = 8
+    stride = np.ceil(np.array(slide.dimensions)/steps).astype(int)
+    try:
+        slide_mpp = float(slide.properties[openslide.PROPERTY_NAME_MPP_X])
+        print(f"Read slide MPP of {slide_mpp} from meta-data")
+    except KeyError:
+        #if it fails, then try out missing mpp handler
+        #TODO: create handlers for different image types
+        try:
+            slide_mpp = handle_missing_mpp(slide)
+        except:
+            print(f"Error: couldn't load MPP from slide!")
+            return None
+    tile_target_size = np.round(stride*slide_mpp/target_mpp).astype(int)
+    #changed max amount of threads used
+    with futures.ThreadPoolExecutor(os.cpu_count()) as executor:
+        # map from future to its (row, col) index
+        future_coords: Dict[futures.Future, Tuple[int, int]] = {}
+        for i in range(steps):  # row
+            for j in range(steps):  # column
+                future = executor.submit(
+                    _load_tile, slide, (stride*(j, i)), stride, tile_target_size)
+                future_coords[future] = (i, j)
+
+        # write the loaded tiles into an image as soon as they are loaded
+        im = np.zeros((*(tile_target_size*steps)[::-1], 3), dtype=np.uint8)
+        for tile_future in tqdm(futures.as_completed(future_coords), total=steps*steps, desc='Reading WSI tiles', leave=False):
+            i, j = future_coords[tile_future]
+            tile = tile_future.result()
+            x, y = tile_target_size * (j, i)
+            im[y:y+tile.shape[0], x:x+tile.shape[1], :] = tile
+
+    return im
+
+def handle_missing_mpp(slide: openslide.OpenSlide) -> float:
+    logging.exception("Missing mpp in metadata of this file format, reading mpp from metadata")
+    import xml.dom.minidom as minidom
+    xml_path = slide.properties['tiff.ImageDescription']
+    doc = minidom.parseString(xml_path)
+    collection = doc.documentElement
+    images = collection.getElementsByTagName("Image")
+    pixels = images[0].getElementsByTagName("Pixels")
+    #tile_size_px = um_per_tile / float(pixels[0].getAttribute("PhysicalSizeX"))
+    mpp = float(pixels[0].getAttribute("PhysicalSizeX"))
+    return mpp
+
+def get_raw_tile_list(I_shape: tuple, bg_reject_array: np.array, rejected_tile_array: np.array, patch_shapes: np.array):
+    canny_output_array=[]
+    for i in range(len(bg_reject_array)):
+        if not rejected_tile_array[i]:
+            canny_output_array.append(np.array(bg_reject_array[i]))
+
+    canny_img = PIL.Image.new("RGB", (I_shape[1], I_shape[0]))
+    coords_list=[]
+    i_range = range(I_shape[0]//patch_shapes[0][0])
+    j_range = range(I_shape[1]//patch_shapes[0][1])
+
+    for i in i_range:
+        for j in j_range:
+            idx = i*len(j_range) + j
+            canny_img.paste(PIL.Image.fromarray(np.array(bg_reject_array[idx])), (j*patch_shapes[idx][1], 
+            i*patch_shapes[idx][0],j*patch_shapes[idx][1]+patch_shapes[idx][1],i*patch_shapes[idx][0]+patch_shapes[idx][0]))
+            
+            if not rejected_tile_array[idx]:
+                coords_list.append((j*patch_shapes[idx][1], i*patch_shapes[idx][0]))
+
+    return canny_img, canny_output_array, coords_list
+
+
+def process_slide_jpg(slide_jpg: PIL.Image):
+    img_norm_wsi_jpg = PIL.Image.open(slide_jpg)
+    image_array = np.array(img_norm_wsi_jpg)
+    canny_norm_patch_list = []
+    coords_list=[]
+    total=0
+    patch_saved=0
+    for i in range(0, image_array.shape[0]-224, 224):
+        for j in range(0, image_array.shape[1]-224, 224):
+            total+=1
+            patch = image_array[j:j+224, i:i+224, :]
+            if not np.all(patch):
+                canny_norm_patch_list.append(patch)
+                coords_list.append((j,i))
+                patch_saved+=1
+    return canny_norm_patch_list, coords_list, patch_saved, total
+
+
+# test get_raw_tile_list function
+def test_get_raw_tile_list():
+    img = np.random.randint(0, 255, size=(1000, 1000, 3), dtype=np.uint8)
+    canny_img, canny_patch_list, coords_list = get_raw_tile_list(img.shape, img, img, (224,224))
+    assert len(canny_patch_list) == 4
+    assert len(coords_list) == 4
+    assert canny_patch_list[0].shape == (224,224,3)
+    assert coords_list[0] == (0,0)

--- a/marugoto/marugoto/extract/extract.py
+++ b/marugoto/marugoto/extract/extract.py
@@ -62,7 +62,7 @@ def get_mask_from_thumb(thumb, threshold: int) -> np.ndarray:
 #TODO: replace slide_tile_paths with the actual tiles which are in memory
 def extract_features_(
         *,
-        model, model_name, norm_wsi_img: np.ndarray, coords: list, wsi_name: str, outdir: Path, augmented_repetitions: int = 0,
+        model, model_name, norm_wsi_img: np.ndarray, coords: list, wsi_name: str, outdir: Path, augmented_repetitions: int = 0, cores: int = 8
 ) -> None:
     """Extracts features from slide tiles.
 
@@ -110,7 +110,7 @@ def extract_features_(
 
     ds = ConcatDataset([unaugmented_ds, augmented_ds])
     dl = torch.utils.data.DataLoader(
-        ds, batch_size=64, shuffle=False, num_workers=12, drop_last=False)
+        ds, batch_size=64, shuffle=False, num_workers=cores, drop_last=False)
 
     model = model.eval()
 

--- a/marugoto/marugoto/extract/extract.py
+++ b/marugoto/marugoto/extract/extract.py
@@ -92,10 +92,6 @@ def extract_features_(
         transforms.ToTensor(),
         transforms.Normalize([0.485, 0.456, 0.406], [0.229, 0.224, 0.225])
     ])
-    outdir = Path(outdir)
-    outdir.mkdir(exist_ok=True, parents=True)
-    patchpatch = Path(f'{outdir}/patches')
-    patchpatch.mkdir(exist_ok=True,parents=True)
 
     extractor_string = f'marugoto-extract-v{__version__}_{model_name}'
     with open(outdir/'info.json', 'w') as f:

--- a/marugoto/marugoto/extract/extract.py
+++ b/marugoto/marugoto/extract/extract.py
@@ -116,12 +116,12 @@ def extract_features_(
         feats.append(
             model(batch.type_as(next(model.parameters()))).half().cpu().detach())
         
-    norm_method = "macenko" if is_norm else "raw"
+    norm_method = "E2E_macenko_" if is_norm else "E2E_raw_"
     model_name_norm = Path(norm_method+model_name)
-    output_file_dir = outdir.parent/model_name_norm/outdir.name
+    output_file_dir = outdir.parent/model_name_norm
     output_file_dir.mkdir(parents=True, exist_ok=True)
 
-    with h5py.File(f'{output_file_dir}.h5', 'w') as f:
+    with h5py.File(f'{output_file_dir/outdir.name}.h5', 'w') as f:
         f['coords'] = coords
         f['feats'] = torch.concat(feats).cpu().numpy()
         f['augmented'] = np.repeat(

--- a/marugoto/marugoto/extract/extract.py
+++ b/marugoto/marugoto/extract/extract.py
@@ -94,7 +94,7 @@ def extract_features_(
     ])
 
     extractor_string = f'marugoto-extract-v{__version__}_{model_name}'
-    with open(outdir/'info.json', 'w') as f:
+    with open(outdir.parent/'info.json', 'w') as f:
         json.dump({'extractor': extractor_string,
                   'augmented_repetitions': augmented_repetitions}, f)
 
@@ -115,7 +115,7 @@ def extract_features_(
         feats.append(
             model(batch.type_as(next(model.parameters()))).half().cpu().detach())
 
-    with h5py.File(f'{outdir/wsi_name}.h5', 'w') as f:
+    with h5py.File(f'{outdir}.h5', 'w') as f:
         f['coords'] = coords
         f['feats'] = torch.concat(feats).cpu().numpy()
         f['augmented'] = np.repeat(

--- a/marugoto/marugoto/extract/extract.py
+++ b/marugoto/marugoto/extract/extract.py
@@ -11,31 +11,15 @@ from torchvision import transforms
 import numpy as np
 from tqdm import tqdm
 import h5py
-
+import os
+from tqdm import tqdm
+import numpy as np
+import PIL
+from pathlib import Path
 from . import __version__
 
 
 __all__ = ['extract_features_']
-
-import os
-from matplotlib import pyplot as plt
-import openslide
-from tqdm import tqdm
-import numpy as np
-# from fastai.vision.all import load_learner
-# from pyzstd import ZstdFile
-import PIL
-import cv2
-import argparse
-import io
-from pathlib import Path
-import sys
-import shutil
-from typing import Dict, Tuple
-from concurrent import futures
-# from urllib.parse import urlparse
-import warnings
-import glob
 
 # supress DecompressionBombWarning: yes, our files are really that big (‘-’*)
 PIL.Image.MAX_IMAGE_PIXELS = None
@@ -91,9 +75,6 @@ def extract_features_(
             only one, non-augmentation iteration will be done.
     """
 
-    #TODO: remove augmented repetitions number
-    #augmented_repetitions = 10
-
     normal_transform = transforms.Compose([
         transforms.Resize(224),
         transforms.CenterCrop(224),
@@ -121,23 +102,9 @@ def extract_features_(
         json.dump({'extractor': extractor_string,
                   'augmented_repetitions': augmented_repetitions}, f)
 
-    
-    # for slide_tile_path in tqdm(slide_tile_paths):
-    #     slide_tile_path = Path(slide_tile_path)
-    #     # check if h5 for slide already exists / slide_tile_path path contains tiles
-    #     if (h5outpath := outdir/f'{slide_tile_path.name}.h5').exists():
-    #         print(f'{h5outpath} already exists.  Skipping...')
-    #         continue
-    #     if not next(slide_tile_path.glob('*.jpg'), False):
-    #         print(f'No tiles in {slide_tile_path}.  Skipping...')
-    #         continue
-    
-    # Everything below was indented 1 tab in the for 
-    #TODO: create dataset which contains the tiles instead of only the paths?
-
     unaugmented_ds = SlideTileDataset(norm_wsi_img, normal_transform)
-    augmented_ds = [] #SlideTileDataset(patch_list, augmenting_transform,
-                                    #repetitions=augmented_repetitions)
+    augmented_ds = []
+
     #clean up memory
     del norm_wsi_img
 

--- a/marugoto/marugoto/extract/extract.py
+++ b/marugoto/marugoto/extract/extract.py
@@ -115,7 +115,7 @@ def extract_features_(
         feats.append(
             model(batch.type_as(next(model.parameters()))).half().cpu().detach())
 
-    with h5py.File(f'{outdir}.h5', 'w') as f:
+    with h5py.File(f'{outdir/wsi_name}.h5', 'w') as f:
         f['coords'] = coords
         f['feats'] = torch.concat(feats).cpu().numpy()
         f['augmented'] = np.repeat(

--- a/marugoto/marugoto/extract/extract.py
+++ b/marugoto/marugoto/extract/extract.py
@@ -116,7 +116,7 @@ def extract_features_(
         feats.append(
             model(batch.type_as(next(model.parameters()))).half().cpu().detach())
 
-    with h5py.File(f'{outdir/outdir.name}.h5', 'w') as f:
+    with h5py.File(f'{outdir}.h5', 'w') as f:
         f['coords'] = coords
         f['feats'] = torch.concat(feats).cpu().numpy()
         f['augmented'] = np.repeat(

--- a/marugoto/marugoto/extract/extract.py
+++ b/marugoto/marugoto/extract/extract.py
@@ -115,13 +115,8 @@ def extract_features_(
     for batch in tqdm(dl, leave=False):
         feats.append(
             model(batch.type_as(next(model.parameters()))).half().cpu().detach())
-        
-    norm_method = "E2E_macenko_" if is_norm else "E2E_raw_"
-    model_name_norm = Path(norm_method+model_name)
-    output_file_dir = outdir.parent/model_name_norm
-    output_file_dir.mkdir(parents=True, exist_ok=True)
 
-    with h5py.File(f'{output_file_dir/outdir.name}.h5', 'w') as f:
+    with h5py.File(f'{outdir/outdir.name}.h5', 'w') as f:
         f['coords'] = coords
         f['feats'] = torch.concat(feats).cpu().numpy()
         f['augmented'] = np.repeat(

--- a/marugoto/marugoto/extract/extract.py
+++ b/marugoto/marugoto/extract/extract.py
@@ -115,7 +115,7 @@ def extract_features_(
         feats.append(
             model(batch.type_as(next(model.parameters()))).half().cpu().detach())
 
-    with h5py.File(f'{outdir}.h5', 'w') as f:
+    with h5py.File(f'{outdir.parent/model_name/outdir.name}.h5', 'w') as f:
         f['coords'] = coords
         f['feats'] = torch.concat(feats).cpu().numpy()
         f['augmented'] = np.repeat(

--- a/run_wsi_norm.sh
+++ b/run_wsi_norm.sh
@@ -1,5 +1,17 @@
 #!/bin/bash
 
+
+##### ONLY THINGS TO FILL IN
+# Default values, use absolute paths only!
+wsi_dir="wsi_samples/"                #path
+cache_dir="workspace/output/"         #path
+output_dir="output/"                  #path
+gpu_ids="1"                           #select GPU ID
+extract="ctranspath"                  #retccl or ctranspath
+model_file="mlcontext/ctranspath.pth" #path, downloaded with setup.sh
+#####
+
+
 # Usage information
 usage() {
     echo "Usage: $(basename "$0") [-h] [-d <wsi_dir>] [-c <cache_dir>] [-o <output_dir>] [-m <model_file>] [-g <gpu_ids>]"
@@ -13,14 +25,6 @@ usage() {
     echo "  -g <gpu_ids>     Comma-separated list of GPU IDs to use (default: 1)"
     echo ""
 }
-
-# Default values
-wsi_dir="wsi_samples/"
-cache_dir="workspace/output/"
-output_dir="output/"
-gpu_ids="1"
-extract="ctranspath"
-model_file="mlcontext/ctranspath.pth"
 
 # Process command-line arguments
 while getopts "hd:c:o:m:g:e:" opt; do
@@ -45,13 +49,10 @@ fi
 echo "Using CUDA devices $gpu_ids"
 export CUDA_VISIBLE_DEVICES="$gpu_ids"
 
-# Get the absolute path of the current directory
-dir=$(pwd)
-
 # Run the WSI normalization script
 python wsi-norm.py \
-    --wsi-dir "$dir/$wsi_dir" \
-    --cache-dir "$dir/$cache_dir" \
-    -o "$dir/$output_dir" \
-    -m "$dir/$model_file" \
+    --wsi-dir "$wsi_dir" \
+    --cache-dir "$cache_dir" \
+    -o "$output_dir" \
+    -m "$model_file" \
     -e $extract

--- a/stainNorm_Macenko.py
+++ b/stainNorm_Macenko.py
@@ -102,7 +102,7 @@ class Normalizer(object):
         return ut.OD_to_RGB(self.stain_matrix_target)
 
 
-    def transform(self, og_img: np.array, bg_rejected_img: np.array, rejected_list: np.array, patch_shapes: list): #TODO
+    def transform(self, og_img: np.array, bg_rejected_img: np.array, rejected_list: np.array, patch_shapes: list, cores: int=8): #TODO: add optional split, patch sizes, overlap
         begin = time.time()
         I = ut.standardize_brightness(og_img)
         after_sb = time.time()
@@ -120,7 +120,7 @@ class Normalizer(object):
         split=True
         if split:
             #added concurent concentrations x stain matrix
-            with futures.ThreadPoolExecutor(os.cpu_count()) as executor: #os.cpu_count()
+            with futures.ThreadPoolExecutor(cores) as executor:
                 future_coords: Dict[futures.Future, int] = {}
 
                 for i, source_concentrations in enumerate(source_concentrations_list):

--- a/wsi-norm.py
+++ b/wsi-norm.py
@@ -113,9 +113,9 @@ if __name__ == "__main__":
 
         progress.set_description(slide_name)
         
-        feat_out_dir = args.output_path/slide_name
+        feat_out_dir = output_file_dir/slide_name
 
-        if not (os.path.exists((f'{args.output_path}/{slide_name}.h5'))):
+        if not (os.path.exists((f'{feat_out_dir}.h5'))):
             # Load WSI as one image
             if (args.only_fex and (slide_jpg := slide_url).exists()) \
                 or (slide_jpg := slide_cache_dir/'norm_slide.jpg').exists():

--- a/wsi-norm.py
+++ b/wsi-norm.py
@@ -57,6 +57,7 @@ if __name__ == "__main__":
     logging.info(f'Stored logfile in {logdir}')
     #init the Macenko normaliser
     print(f"Number of CPUs in the system: {os.cpu_count()}")
+    print(f"Number of CPU cores used: {args.cores}")
     has_gpu=torch.cuda.is_available()
     print(f"GPU is available: {has_gpu}")
     norm=args.norm

--- a/wsi-norm.py
+++ b/wsi-norm.py
@@ -176,7 +176,7 @@ if __name__ == "__main__":
             #measure time performance
             start_time = time.time()
             extract_features_(model=model, model_name=model_name, norm_wsi_img=canny_norm_patch_list,
-                               coords=coords_list, wsi_name=slide_name, outdir=feat_out_dir, cores=args.cores)
+                               coords=coords_list, wsi_name=slide_name, outdir=feat_out_dir, cores=args.cores, is_norm=args.norm)
             print("\n--- Extracted features from slide: %s seconds ---" % (time.time() - start_time))
             #########################
 

--- a/wsi-norm.py
+++ b/wsi-norm.py
@@ -82,7 +82,14 @@ if __name__ == "__main__":
     extractor = FeatureExtractor(args.extractor)
     model, model_name = extractor.init_feat_extractor(checkpoint_path=args.model)
 
+    #create output feature folder, f.e.:
+    #~/output_folder/E2E_macenko_xiyuewang-ctranspath/
     (args.output_path).mkdir(parents=True, exist_ok=True)
+    norm_method = "E2E_macenko_" if args.norm else "E2E_raw_"
+    model_name_norm = Path(norm_method+model_name)
+    output_file_dir = args.output_path.parent/model_name_norm
+    output_file_dir.mkdir(parents=True, exist_ok=True)
+
     total_start_time = time.time()
 
 

--- a/wsi-norm.py
+++ b/wsi-norm.py
@@ -96,21 +96,22 @@ if __name__ == "__main__":
         img_dir = list(args.wsi_dir.glob(f'**/*/{img_name}')) #TODO: CHECK IF THIS IS WORKING
                        
     for slide_url in (progress := tqdm(img_dir, leave=False)):
-        #handle multiple suffixes for filename
-        slide_name = Path(slide_url).stem
-        # extensions = slide_name.suffixes
-        # for _ in extensions:
-        #     slide_name = Path(slide_name).stem
+        
+        if not args.only_fex:
+            slide_name = Path(slide_url).stem
+            slide_cache_dir = args.cache_dir/slide_name
+            slide_cache_dir.mkdir(parents=True, exist_ok=True)
+        else:
+            slide_name = Path(slide_url).parent.name
 
         progress.set_description(slide_name)
-        slide_cache_dir = args.cache_dir/slide_name
-        slide_cache_dir.mkdir(parents=True, exist_ok=True)
         
         feat_out_dir = args.output_path/slide_name
 
         if not (os.path.exists((f'{args.output_path}/{slide_name}.h5'))):
             # Load WSI as one image
-            if (slide_jpg := slide_cache_dir/'norm_slide.jpg').exists():
+            if (args.only_fex and (slide_jpg := slide_url).exists()) \
+                or (slide_jpg := slide_cache_dir/'norm_slide.jpg').exists():
                 canny_norm_patch_list, coords_list, patch_saved, total = process_slide_jpg(slide_jpg)
                 print(f"Loaded normalised canny image, {patch_saved}/{total} tiles remain")
             else:

--- a/wsi-norm.py
+++ b/wsi-norm.py
@@ -41,6 +41,7 @@ if __name__ == '__main__':
     parser.set_defaults(norm=True)
     parser.add_argument('-d', '--del-slide', action='store_true', default=False,
                          help='Removing the original slide after processing.')
+    parser.add_argument('--only-fex', action='store_true', default=False)
 
     args = parser.parse_args()
 
@@ -82,10 +83,18 @@ if __name__ == "__main__":
 
     (args.output_path).mkdir(parents=True, exist_ok=True)
     total_start_time = time.time()
-    svs_dir = sum((list(args.wsi_dir.glob(f'**/*.{ext}'))
-                  for ext in supported_extensions),
-                 start=[])
-    for slide_url in (progress := tqdm(svs_dir, leave=False)):
+
+
+    if not args.only_fex:
+        img_dir = sum((list(args.wsi_dir.glob(f'**/*.{ext}'))
+                    for ext in supported_extensions),
+                    start=[])
+    else:
+        #TODO: read images from slide directory
+        img_name = "norm_slide.jpg" if args.norm else "canny_slide.jpg"
+        img_dir = list(args.wsi_dir.glob(f'**/*/{img_name}')) #TODO: CHECK IF THIS IS WORKING
+                       
+    for slide_url in (progress := tqdm(img_dir, leave=False)):
         #handle multiple suffixes for filename
         slide_name = Path(slide_url)
         extensions = slide_name.suffixes

--- a/wsi-norm.py
+++ b/wsi-norm.py
@@ -1,14 +1,22 @@
 import argparse
-import io
 from pathlib import Path
-import sys
-import shutil
-from typing import Dict, Tuple
-from concurrent import futures
-# from urllib.parse import urlparse
-import warnings
-import glob
 import logging
+import os
+from matplotlib import pyplot as plt
+import openslide
+from tqdm import tqdm
+import PIL
+import stainNorm_Macenko
+import cv2
+from common import supported_extensions
+import time
+from datetime import timedelta
+from pathlib import Path
+import torch
+import torch.nn as nn
+from concurrent_canny_rejection import reject_background
+from loading_slides import process_slide_jpg, load_slide, get_raw_tile_list
+from feature_extractors import FeatureExtractor
 
 
 if __name__ == '__main__':
@@ -16,203 +24,25 @@ if __name__ == '__main__':
         description='Normalise WSI directly.')
 
     parser.add_argument('-o', '--output-path', type=Path, required=True,
-                        help='Path to save results to.')
+                        help='Path to save features to.')
     parser.add_argument('--wsi-dir', metavar='DIR', type=Path, required=True,
                         help='Path of where the whole-slide images are.')
     parser.add_argument('-m', '--model', metavar='DIR', type=Path, required=True,
                         help='Path of where model for the feature extractor is.')
     parser.add_argument('--cache-dir', type=Path, default=None,
-        help='Directory to cache extracted features etc. in.')
-    parser.add_argument('-e', '--extractor', type=str, help='Feature extractor to use.')
-    # parser.add_argument('--cache-dir', type=Path, default=None,
-    #                     help='Directory to cache extracted features etc. in.')
+        help='Directory to store resulting slide JPGs.')
+    parser.add_argument('-e', '--extractor', type=str, 
+                        help='Feature extractor to use.')
+    parser.add_argument('-n','--norm', action='store_true')
+    parser.add_argument('--no-norm', dest='norm', action='store_false')
+    parser.set_defaults(norm=True)
+    parser.add_argument('-d', '--del-slide', action='store_true', default=False,
+                         help='Removing the original slide after processing.')
 
     args = parser.parse_args()
 
 
-
-
-# if (p := './RetCCL') not in sys.path:
-#     sys.path = [p] + sys.path
-# import ResNet
-# import torch.nn as nn
-# import torch
-# from torchvision import transforms
-import os
-from matplotlib import pyplot as plt
-import openslide
-from tqdm import tqdm
-import numpy as np
-# from fastai.vision.all import load_learner
-# from pyzstd import ZstdFile
-import PIL
-import stainNorm_Macenko
-import cv2
-from common import supported_extensions
-from numba import jit
-
-# supress DecompressionBombWarning: yes, our files are really that big (‘-’*)
 PIL.Image.MAX_IMAGE_PIXELS = None
-
-
-def _load_tile(
-    slide: openslide.OpenSlide, pos: Tuple[int, int], stride: Tuple[int, int], target_size: Tuple[int, int]
-) -> np.ndarray:
-    # Loads part of a WSI. Used for parallelization with ThreadPoolExecutor
-    tile = slide.read_region(pos, 0, stride).convert('RGB').resize(target_size)
-    return np.array(tile)
-
-
-def load_slide(slide: openslide.OpenSlide, target_mpp: float = 256/224) -> np.ndarray:
-    """Loads a slide into a numpy array."""
-    # We load the slides in tiles to
-    #  1. parallelize the loading process
-    #  2. not use too much data when then scaling down the tiles from their
-    #     initial size
-    steps = 8
-    stride = np.ceil(np.array(slide.dimensions)/steps).astype(int)
-    try:
-        slide_mpp = float(slide.properties[openslide.PROPERTY_NAME_MPP_X])
-        print(f"Read slide MPP of {slide_mpp} from meta-data")
-    except KeyError:
-        #if it fails, then try out missing mpp handler
-        #TODO: create handlers for different image types
-        try:
-            slide_mpp = handle_missing_mpp(slide)
-        except:
-            print(f"Error: couldn't load MPP from slide!")
-            return None
-    tile_target_size = np.round(stride*slide_mpp/target_mpp).astype(int)
-    #changed max amount of threads used
-    with futures.ThreadPoolExecutor(os.cpu_count()) as executor:
-        # map from future to its (row, col) index
-        future_coords: Dict[futures.Future, Tuple[int, int]] = {}
-        for i in range(steps):  # row
-            for j in range(steps):  # column
-                future = executor.submit(
-                    _load_tile, slide, (stride*(j, i)), stride, tile_target_size)
-                future_coords[future] = (i, j)
-
-        # write the loaded tiles into an image as soon as they are loaded
-        im = np.zeros((*(tile_target_size*steps)[::-1], 3), dtype=np.uint8)
-        for tile_future in tqdm(futures.as_completed(future_coords), total=steps*steps, desc='Reading WSI tiles', leave=False):
-            i, j = future_coords[tile_future]
-            tile = tile_future.result()
-            x, y = tile_target_size * (j, i)
-            im[y:y+tile.shape[0], x:x+tile.shape[1], :] = tile
-
-    return im
-
-def handle_missing_mpp(slide: openslide.OpenSlide) -> float:
-    logging.exception("Missing mpp in metadata of this file format, reading mpp from metadata")
-    import xml.dom.minidom as minidom
-    xml_path = slide.properties['tiff.ImageDescription']
-    doc = minidom.parseString(xml_path)
-    collection = doc.documentElement
-    images = collection.getElementsByTagName("Image")
-    pixels = images[0].getElementsByTagName("Pixels")
-    #tile_size_px = um_per_tile / float(pixels[0].getAttribute("PhysicalSizeX"))
-    mpp = float(pixels[0].getAttribute("PhysicalSizeX"))
-    return mpp
-
-
-import time
-from datetime import timedelta
-
-#xiyue wang fex
-import hashlib
-from pathlib import Path
-import torch
-import torch.nn as nn
-from marugoto.marugoto.extract.extract import extract_features_
-from marugoto.marugoto.extract.xiyue_wang.RetCLL import ResNet
-from marugoto.marugoto.extract.ctranspath.swin_transformer import swin_tiny_patch4_window7_224, ConvStem
-from concurrent_canny_rejection import reject_background
-from PIL import Image
-
-# %%
-
-import hashlib
-import torch
-import torch.nn as nn
-from marugoto.marugoto.extract.extract import extract_features_
-from marugoto.marugoto.extract.xiyue_wang.RetCLL import ResNet
-from marugoto.marugoto.extract.ctranspath.swin_transformer import swin_tiny_patch4_window7_224, ConvStem
-from PIL import Image
-
-class FeatureExtractor:
-    def __init__(self, model_type):
-        self.model_type = model_type
-
-    def extract_features(self, norm_wsi_img: PIL.Image, wsi_name: str, coords: list, checkpoint_path: str, outdir: Path, **kwargs):
-        """Extracts features from slide tiles.
-        Args:
-            checkpoint_path:  Path to the model checkpoint file.
-        """
-        sha256 = hashlib.sha256()
-        with open(checkpoint_path, 'rb') as f:
-            while True:
-                data = f.read(1 << 16)
-                if not data:
-                    break
-                sha256.update(data)
-
-        if self.model_type == 'retccl':
-            assert sha256.hexdigest() == '931956f31d3f1a3f6047f3172b9e59ee3460d29f7c0c2bb219cbc8e9207795ff'
-
-            model = ResNet.resnet50(num_classes=128, mlp=False, two_branch=False, normlinear=True)
-            pretext_model = torch.load(checkpoint_path, map_location=torch.device('cpu'))
-            model.fc = nn.Identity()
-            model.load_state_dict(pretext_model, strict=True)
-
-            if torch.cuda.is_available():
-                model = model.cuda()
-
-            print("RetCCL model successfully initialised...")
-
-            return extract_features_(norm_wsi_img=norm_wsi_img, wsi_name=wsi_name, coords=coords, model=model, outdir=outdir, model_name='xiyuewang-retcll-931956f3', **kwargs)
-
-        elif self.model_type == 'ctranspath':
-            assert sha256.hexdigest() == '7c998680060c8743551a412583fac689db43cec07053b72dfec6dcd810113539'
-
-            model = swin_tiny_patch4_window7_224(embed_layer=ConvStem, pretrained=False)
-            model.head = nn.Identity()
-
-            ctranspath = torch.load(checkpoint_path, map_location=torch.device('cpu'))
-            if torch.cuda.is_available():
-                model = model.cuda()
-            # print keys and values of ctranspath
-
-            model.load_state_dict(ctranspath['model'], strict=True)
-            print("CTransPath model successfully initialised...")
-
-            return extract_features_(norm_wsi_img=norm_wsi_img, wsi_name=wsi_name, coords=coords, model=model, outdir=outdir,
-                                     model_name='xiyuewang-ctranspath-7c998680', **kwargs)
-
-        else:
-            raise ValueError('Invalid model type')
-
-def get_raw_tile_list(I_shape: tuple, bg_reject_array: np.array, rejected_tile_array: np.array, patch_shapes: np.array):
-    canny_output_array=[]
-    for i in range(len(bg_reject_array)):
-        if not rejected_tile_array[i]:
-            canny_output_array.append(np.array(bg_reject_array[i]))
-
-    canny_img = Image.new("RGB", (I_shape[1], I_shape[0]))
-    coords_list=[]
-    i_range = range(I_shape[0]//patch_shapes[0][0])
-    j_range = range(I_shape[1]//patch_shapes[0][1])
-
-    for i in i_range:
-        for j in j_range:
-            idx = i*len(j_range) + j
-            canny_img.paste(Image.fromarray(np.array(bg_reject_array[idx])), (j*patch_shapes[idx][1], 
-            i*patch_shapes[idx][0],j*patch_shapes[idx][1]+patch_shapes[idx][1],i*patch_shapes[idx][0]+patch_shapes[idx][0]))
-            
-            if not rejected_tile_array[idx]:
-                coords_list.append((j*patch_shapes[idx][1], i*patch_shapes[idx][0]))
-
-    return canny_img, canny_output_array, coords_list
 
 if __name__ == "__main__":
     # print current dir
@@ -226,9 +56,11 @@ if __name__ == "__main__":
     print(f"Number of CPUs in the system: {os.cpu_count()}")
     has_gpu=torch.cuda.is_available()
     print(f"GPU is available: {has_gpu}")
+    norm=args.norm
+
     if has_gpu:
         print(f"Number of GPUs in the system: {torch.cuda.device_count()}")
-    norm=True
+
     if norm:
         print("\nInitialising Macenko normaliser...")
         target = cv2.imread('normalization_template.jpg') #TODO: make scaleable with path
@@ -239,8 +71,8 @@ if __name__ == "__main__":
         logging.info('Running WSI to normalised feature extraction...')
     else:
         logging.info('Running WSI to raw feature extraction...')
-    # norm = MacenkoNormalizer()
-    # norm.fit(target)
+
+    (args.output_path).mkdir(parents=True, exist_ok=True)
     total_start_time = time.time()
     svs_dir = sum((list(args.wsi_dir.glob(f'**/*.{ext}'))
                   for ext in supported_extensions),
@@ -255,26 +87,11 @@ if __name__ == "__main__":
         progress.set_description(slide_name)
         slide_cache_dir = args.cache_dir/slide_name
         slide_cache_dir.mkdir(parents=True, exist_ok=True)
-        # print('\n')
-        # print((f'{args.cache_dir}/{slide_name}.h5'))
-        # print((os.path.exists((f'{args.cache_dir}/{slide_name}.h5'))))
+
         if not (os.path.exists((f'{args.cache_dir}/{slide_name}.h5'))):
             # Load WSI as one image
             if (slide_jpg := slide_cache_dir/'norm_slide.jpg').exists():
-                img_norm_wsi_jpg = PIL.Image.open(slide_jpg)
-                image_array = np.array(img_norm_wsi_jpg)
-                canny_norm_patch_list = []
-                coords_list=[]
-                total=0
-                patch_saved=0
-                for i in range(0, image_array.shape[0]-224, 224):
-                    for j in range(0, image_array.shape[1]-224, 224):
-                        total+=1
-                        patch = image_array[j:j+224, i:i+224, :]
-                        if not np.all(patch):
-                            canny_norm_patch_list.append(patch)
-                            coords_list.append((j,i))
-                            patch_saved+=1
+                canny_norm_patch_list, coords_list, patch_saved, total = process_slide_jpg(slide_jpg)
                 print(f"Loaded normalised canny image, {patch_saved}/{total} tiles remain")
             else:
                 logging.info(f"\nLoading {slide_name}")
@@ -291,14 +108,15 @@ if __name__ == "__main__":
                 start_time = time.time()
                 slide_array = load_slide(slide)
                 if slide_array is None:
-                    print(f"Skipping slide and deleting {slide_url} due to missing MPP...")
-                    os.remove(str(slide_url))
+                    if args.del_slide:
+                        print(f"Skipping slide and deleting {slide_url} due to missing MPP...")
+                        os.remove(str(slide_url))
                     continue
                 #save raw .svs jpg
-                (Image.fromarray(slide_array)).save(f'{slide_cache_dir}/slide.jpg')
+                (PIL.Image.fromarray(slide_array)).save(f'{slide_cache_dir}/slide.jpg')
 
-                #remove .SVS from memory (couple GB)
-                #del slide
+                #remove .SVS from memory
+                del slide
                 
                 print("\n--- Loaded slide: %s seconds ---" % (time.time() - start_time))
                 #########################
@@ -321,15 +139,15 @@ if __name__ == "__main__":
 
                 print("Saving Canny background rejected image...")
                 canny_img.save(f'{slide_cache_dir}/canny_slide.jpg')
-                # norm_wsi_jpg = norm.transform(np.array(slide_array))
                 
                 #remove original slide jpg from memory
                 del slide_array
-                #print(f"Deleting slide {slide_name} from local folder...")
-                #os.remove(str(slide_url)) #TO-DO: Make optional
+                
+                #optionally removing the original slide from harddrive
+                if args.del_slide:
+                    print(f"Deleting slide {slide_name} from local folder...")
+                    os.remove(str(slide_url))
 
-
-                # img_norm_wsi_jpg = PIL.Image.fromarray(norm_wsi_jpg)
                 img_norm_wsi_jpg.save(slide_jpg) #save WSI.svs -> WSI.jpg
 
             print(f"Extracting {args.extractor} features from {slide_name}")
@@ -337,50 +155,14 @@ if __name__ == "__main__":
             #measure time performance
             start_time = time.time()
             extractor = FeatureExtractor(args.extractor)
-            features = extractor.extract_features(norm_wsi_img=canny_norm_patch_list, wsi_name=slide_name, coords=coords_list, checkpoint_path=args.model, outdir=slide_cache_dir)
+            features = extractor.extract_features(norm_wsi_img=canny_norm_patch_list, wsi_name=slide_name, coords=coords_list, checkpoint_path=args.model, outdir=args.output_path)
             print("\n--- Extracted features from slide: %s seconds ---" % (time.time() - start_time))
             #########################
-            #print(f"Deleting slide {slide_name} from local folder...")
-            #os.remove(str(slide_url))
 
         else:
             print(f"{slide_name}.h5 already exists. Skipping...")
-            #print(f"Deleting slide {slide_name} from local folder...")
-            #os.remove(str(slide_url))
+            if args.del_slide:
+                print(f"Deleting slide {slide_name} from local folder...")
+                os.remove(str(slide_url))
 
     print(f"--- End-to-end processing time of {len(svs_dir)} slides: {str(timedelta(seconds=(time.time() - total_start_time)))} ---")
-
-# test get_raw_tile_list function
-def test_get_raw_tile_list():
-    img = np.random.randint(0, 255, size=(1000, 1000, 3), dtype=np.uint8)
-    canny_img, canny_patch_list, coords_list = get_raw_tile_list(img.shape, img, img, (224,224))
-    assert len(canny_patch_list) == 4
-    assert len(coords_list) == 4
-    assert canny_patch_list[0].shape == (224,224,3)
-    assert coords_list[0] == (0,0)
-
-# test reject_background function
-def test_reject_background():
-    img = np.random.randint(0, 255, size=(1000, 1000, 3), dtype=np.uint8)
-    bg_reject_array, rejected_tile_array, patch_shapes = reject_background(img = img, patch_size=(224,224), step=224, outdir='.', save_tiles=False)
-    assert bg_reject_array.shape == (1000, 1000, 3)
-    assert rejected_tile_array.shape == (1000, 1000, 3)
-    assert patch_shapes == (224,224)
-
-    # test that the rejected tiles are all black
-    assert np.all(rejected_tile_array == 0)
-
-# test extract_xiyuewang_features_ function
-def test_extract_xiyuewang_features_():
-    img = np.random.randint(0, 255, size=(1000, 1000, 3), dtype=np.uint8)
-    feature_extractor = FeatureExtractor('retccl')
-    feature_extractor.extract_features(norm_wsi_img=img, wsi_name='test', coords=[(0,0)], checkpoint_path='.', outdir='.')
-
-    # test that the output file exists
-    assert os.path.exists('test.h5')
-
-    # test that the output file is not empty
-    assert os.path.getsize('test.h5') > 0
-
-    # remove the output file
-    os.remove('test.h5')

--- a/wsi-norm.py
+++ b/wsi-norm.py
@@ -85,9 +85,10 @@ if __name__ == "__main__":
     #create output feature folder, f.e.:
     #~/output_folder/E2E_macenko_xiyuewang-ctranspath/
     (args.output_path).mkdir(parents=True, exist_ok=True)
+    
     norm_method = "E2E_macenko_" if args.norm else "E2E_raw_"
     model_name_norm = Path(norm_method+model_name)
-    output_file_dir = args.output_path.parent/model_name_norm
+    output_file_dir = args.output_path/model_name_norm
     output_file_dir.mkdir(parents=True, exist_ok=True)
 
     total_start_time = time.time()

--- a/wsi-norm.py
+++ b/wsi-norm.py
@@ -97,16 +97,18 @@ if __name__ == "__main__":
                        
     for slide_url in (progress := tqdm(img_dir, leave=False)):
         #handle multiple suffixes for filename
-        slide_name = Path(slide_url)
-        extensions = slide_name.suffixes
-        for _ in extensions:
-            slide_name = Path(slide_name).stem
+        slide_name = Path(slide_url).stem
+        # extensions = slide_name.suffixes
+        # for _ in extensions:
+        #     slide_name = Path(slide_name).stem
 
         progress.set_description(slide_name)
         slide_cache_dir = args.cache_dir/slide_name
         slide_cache_dir.mkdir(parents=True, exist_ok=True)
+        
+        feat_out_dir = args.output_path/slide_name
 
-        if not (os.path.exists((f'{args.cache_dir}/{slide_name}.h5'))):
+        if not (os.path.exists((f'{args.output_path}/{slide_name}.h5'))):
             # Load WSI as one image
             if (slide_jpg := slide_cache_dir/'norm_slide.jpg').exists():
                 canny_norm_patch_list, coords_list, patch_saved, total = process_slide_jpg(slide_jpg)
@@ -173,7 +175,7 @@ if __name__ == "__main__":
             #measure time performance
             start_time = time.time()
             extract_features_(model=model, model_name=model_name, norm_wsi_img=canny_norm_patch_list,
-                               coords=coords_list, wsi_name=slide_name, outdir=args.output_path, cores=args.cores)
+                               coords=coords_list, wsi_name=slide_name, outdir=feat_out_dir, cores=args.cores)
             print("\n--- Extracted features from slide: %s seconds ---" % (time.time() - start_time))
             #########################
 

--- a/wsi-norm.py
+++ b/wsi-norm.py
@@ -90,9 +90,8 @@ if __name__ == "__main__":
     model_name_norm = Path(norm_method+model_name)
     output_file_dir = args.output_path/model_name_norm
     output_file_dir.mkdir(parents=True, exist_ok=True)
-
+    
     total_start_time = time.time()
-
 
     if not args.only_fex:
         img_dir = sum((list(args.wsi_dir.glob(f'**/*.{ext}'))
@@ -121,7 +120,7 @@ if __name__ == "__main__":
             if (args.only_fex and (slide_jpg := slide_url).exists()) \
                 or (slide_jpg := slide_cache_dir/'norm_slide.jpg').exists():
                 canny_norm_patch_list, coords_list, patch_saved, total = process_slide_jpg(slide_jpg)
-                print(f"Loaded normalised canny image, {patch_saved}/{total} tiles remain")
+                print(f"Loaded {img_name}, {patch_saved}/{total} tiles remain")
             else:
                 logging.info(f"\nLoading {slide_name}")
                 try:

--- a/wsi-norm.py
+++ b/wsi-norm.py
@@ -78,6 +78,7 @@ if __name__ == "__main__":
         logging.info('Running WSI to raw feature extraction...')
 
     #initialize the feature extraction model
+    print(f"\nInitialising {args.extractor} model...")
     extractor = FeatureExtractor(args.extractor)
     model, model_name = extractor.init_feat_extractor(checkpoint_path=args.model)
 
@@ -182,4 +183,4 @@ if __name__ == "__main__":
                 print(f"Deleting slide {slide_name} from local folder...")
                 os.remove(str(slide_url))
 
-    print(f"--- End-to-end processing time of {len(svs_dir)} slides: {str(timedelta(seconds=(time.time() - total_start_time)))} ---")
+    print(f"--- End-to-end processing time of {len(img_dir)} slides: {str(timedelta(seconds=(time.time() - total_start_time)))} ---")


### PR DESCRIPTION
Functions have been moved into different files to keep an oversight of the main script, wsi-norm.py.
Moreover, several features have been added to the code. By adding flags, one can now:

1. Normalization: turn on (default, --norm) or turn off (--no-norm)
2. Delete original slide after processing / cannot read MPP (--del-slide, doesn't delete by default)
3. Select the number of CPU cores for your device (--cores, 8 by default)
4. Only run feature extraction on JPG slides from previous runs, without needing to download the WSI as well (--only-fex)

Several other updates:

1. The initialization of the feature extraction model has been moved forward, thus only being initialized at start-up and not every iteration to improve efficiency.
2. The folder structure of the output has been improved. The cache and feature output directory have been split into two different directories. Also, the feature output directories are now named based on the parameters of the pipeline; namely the use of normalization and which model was used for extraction. 
3. In the script to insert the parameters, run_wsi_norm.py, the paths have been changed to absolute (instead of relative), and moved to the top of the file to avoid scrolling. Note that additional flags still need to be added manually at the bottom of the script.
4. Slide names with unique characters in the name are now handled correctly, without removing parts of the full name. This used to happen with TCGA slides, where there was a '.' in the middle of the filename, alongside the .svs extension at the end.
5. The README has been updated accordingly, focussed on the deployment on a local computer. A public guide for clusters, such as the HPC, will be added soon.