### PR TITLE
Handle MPP error

### DIFF
--- a/wsi-norm.py
+++ b/wsi-norm.py
@@ -19,6 +19,7 @@ from datetime import timedelta
 from pathlib import Path
 import torch
 from helpers import stainNorm_Macenko
+from helpers.exceptions import MPPExtractionError
 from helpers.common import supported_extensions
 from helpers.concurrent_canny_rejection import reject_background
 from helpers.loading_slides import process_slide_jpg, load_slide, get_raw_tile_list
@@ -141,8 +142,9 @@ if __name__ == "__main__":
  
                 #measure time performance
                 start_time = time.time()
-                slide_array = load_slide(slide=slide, cores=args.cores)
-                if slide_array is None:
+                try:
+                    slide_array = load_slide(slide=slide, cores=args.cores)
+                except MPPExtractionError:
                     if args.del_slide:
                         print(f"Skipping slide and deleting {slide_url} due to missing MPP...")
                         os.remove(str(slide_url))


### PR DESCRIPTION
The `load_slide` function does not return `None` if the MPP cannot be read; instead it throws a `MPPExtractionError`. So instead of checking for `None`, we should catch the error.